### PR TITLE
Feat/운동 히스토리 페이지

### DIFF
--- a/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import mainLogo0 from '@/../public/svgs/mainLogo0.svg';
 import mainLogo25 from '@/../public/svgs/mainLogo25.svg';
 import mainLogo50 from '@/../public/svgs/mainLogo50.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import mainLogo0 from '@/../public/svgs/mainLogo0.svg';
 import mainLogo25 from '@/../public/svgs/mainLogo25.svg';
 import mainLogo50 from '@/../public/svgs/mainLogo50.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 type TWorkspaceTitle = {
   name: string;
   workout: boolean;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 type TWorkspaceTitle = {
   name: string;
   workout: boolean;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/page.tsx
@@ -181,7 +181,7 @@ export default function Page() {
                 >
                   <div
                     className={`w-full h-16 ${
-                      user.isMyself ? 'bg-[#C8F68B]' : 'bg-[#DBEAFE] '
+                      user.isMyself ? 'bg-[#C8F68B]' : 'bg-[#FFFFFF] '
                     } rounded-xl flex items-center justify-between px-3.5`}
                   >
                     <div className='h-8 w-8 rounded-full bg-white mr-3.5 flex items-center justify-center relative'>

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workout/register/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workout/register/page.tsx
@@ -72,20 +72,20 @@ export default function Page() {
   };
 
   return (
-    <div className="">
-      <div className="mb-6">
-        <Label htmlFor="photo" className="flex items-center justify-start mb-2">
-          <Image src={photo} alt="photo" className="mr-1" />
-          <span className="text-base mr-1">사진 등록</span>
-          <span className="text-base">(필수)</span>
+    <div className=''>
+      <div className='mb-6'>
+        <Label htmlFor='photo' className='flex items-center justify-start mb-2'>
+          <Image src={photo} alt='photo' className='mr-1' />
+          <span className='text-base mr-1'>사진 등록</span>
+          <span className='text-base'>(필수)</span>
         </Label>
-        <div className="flex justify-start items-end gap-1">
+        <div className='flex justify-start items-end gap-1'>
           <div
-            className="w-24 h-24 bg-[#F9FAFB] rounded-lg flex justify-center items-center relative"
+            className='w-24 h-24 bg-[#F9FAFB] rounded-lg flex justify-center items-center relative'
             onClick={handleClick}
           >
             <span
-              className="absolute right-0 -top-2 text-white bg-red-500 rounded-full"
+              className='absolute right-0 -top-2 text-white bg-red-500 rounded-full'
               onClick={(e) => handleImageRemove(e)}
             >
               x
@@ -93,11 +93,11 @@ export default function Page() {
             {imagePreview ? (
               <img
                 src={URL.createObjectURL(imagePreview)}
-                alt="preview"
-                className="w-full h-full object-cover rounded-lg"
+                alt='preview'
+                className='w-full h-full object-cover rounded-lg'
               />
             ) : (
-              <Image src={plus} alt="plus" />
+              <Image src={plus} alt='plus' />
             )}
           </div>
           <div onClick={() => setPhotoCheck((v) => !v)}>
@@ -108,8 +108,8 @@ export default function Page() {
             >
               <Image
                 src={photoCheck ? checkedCircle : nonCheckedCircle}
-                alt="check"
-                className="mr-1"
+                alt='check'
+                className='mr-1'
               />
               사진 커뮤니티에도 사진을 등록할까요?
             </span>
@@ -117,46 +117,46 @@ export default function Page() {
 
           <Input
             required
-            id="photo"
-            type="file"
-            className="hidden"
+            id='photo'
+            type='file'
+            className='hidden'
             ref={fileInputRef}
             onChange={handleImageChange}
           />
         </div>
       </div>
-      <hr className="-mx-6 mb-6" />
-      <div className="mb-2">
+      <hr className='-mx-6 mb-6' />
+      <div className='mb-2'>
         <Label
-          htmlFor="pencil"
-          className="flex items-center justify-start mb-2"
+          htmlFor='pencil'
+          className='flex items-center justify-start mb-2'
         >
-          <Image src={pencil} alt="pencil" className="mr-1" />
-          <span className="text-base mr-1">코멘트 작성</span>
-          <span className="text-base">(선택)</span>
+          <Image src={pencil} alt='pencil' className='mr-1' />
+          <span className='text-base mr-1'>코멘트 작성</span>
+          <span className='text-base'>(선택)</span>
         </Label>
         <div>
           <textarea
-            id="pencil"
-            className="bg-[#F9FAFB] px-3 py-[10px] w-full h-24 rounded-lg appearance-none focus:outline-none placeholder:text-xs text-xs"
-            placeholder="운동에 대한 간단한 코멘트를 작성해주세요!"
+            id='pencil'
+            className='bg-[#F9FAFB] px-3 py-[10px] w-full h-24 rounded-lg appearance-none focus:outline-none placeholder:text-xs text-xs'
+            placeholder='운동에 대한 간단한 코멘트를 작성해주세요!'
             value={comment}
             onChange={(e) => setComment(e.target.value)}
           ></textarea>
         </div>
       </div>
 
-      <div className="flex items-center space-x-2 mb-2">
-        <Image src={warning} alt="warning" />
+      <div className='flex items-center space-x-2 mb-2'>
+        <Image src={warning} alt='warning' />
         <label
-          htmlFor="terms"
-          className="font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-[10px] text-[#F87171]"
+          htmlFor='terms'
+          className='font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-[10px] text-[#F87171]'
         >
           성의없는 운동인증은 이의제기를 받을 수 있습니다. 또한 운동인증은 하루
           최대 3번까지만 등록 가능합니다.
         </label>
       </div>
-      <div className="bg-[#EFF6FF] min-h-96 h-full -mx-6">
+      <div className='bg-[#EFF6FF] min-h-96 h-full -mx-6'>
         {workoutInfo.missions.map((item, i) => {
           const isLast = i === workoutInfo.missions.length - 1;
           return (
@@ -168,14 +168,14 @@ export default function Page() {
             >
               <div>
                 <h3>{item.mission}</h3>
-                <h5 className="text-xs font-light">{`${item.score}점`}</h5>
+                <h5 className='text-xs font-light'>{`${item.score}점`}</h5>
               </div>
-              <div className="text-2xl mr-4">{item.count}</div>
+              <div className='text-2xl mr-4'>{item.count}</div>
             </div>
           );
         })}
       </div>
-      <div className="w-full fixed bottom-10">
+      <div className='w-full fixed bottom-10'>
         <button
           className={`py-3 w-[90%] bg-main text-white
              rounded-full flex justify-center items-center text-base`}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
@@ -1,0 +1,16 @@
+interface ApproveStatusMsgProps {
+  isApproved: boolean;
+}
+
+function ApproveStatusMsg({ isApproved }: ApproveStatusMsgProps) {
+  return (
+    <>
+      {isApproved ? (
+        <span className='text-xs text-[#6B7280]'>인증 완료</span>
+      ) : (
+        <span className='text-xs text-[#F87171]'>인증 거부</span>
+      )}
+    </>
+  );
+}
+export default ApproveStatusMsg;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 interface ApproveStatusMsgProps {
   isApproved: boolean;
 }

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/ApproveStatusMsg.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 interface ApproveStatusMsgProps {
   isApproved: boolean;
 }

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+
+import detailVertical from '@/../public/svgs/workspace/workspaceHistory/detailVertical.svg';
+import detailVerticalIsToggled from '@/../public/svgs/workspace/workspaceHistory/detailVerticalIsToggled.svg';
+
+interface IsToggledImageProps {
+  index: number;
+  isToggled: boolean;
+  workoutHistoriesLength: number;
+}
+
+function IsToggledImage({
+  index,
+  isToggled,
+  workoutHistoriesLength,
+}: IsToggledImageProps) {
+  const isLastIndex = index === workoutHistoriesLength - 1;
+  return (
+    <>
+      {isLastIndex ? (
+        <></>
+      ) : (
+        <div>
+          {isToggled ? (
+            <Image
+              src={detailVerticalIsToggled}
+              alt='detailVerticalIsToggled'
+            />
+          ) : (
+            <Image src={detailVertical} alt='detailVertical' />
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+export default IsToggledImage;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 
 import detailVertical from '@/../public/svgs/workspace/workspaceHistory/detailVertical.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/IsToggledImage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import detailVertical from '@/../public/svgs/workspace/workspaceHistory/detailVertical.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkoutHistoryList.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkoutHistoryList.tsx
@@ -1,0 +1,122 @@
+import Image from 'next/image';
+import { useQuery } from '@tanstack/react-query';
+
+import radius from '@/../public/svgs/workspace/workspaceHistory/radius.svg';
+import radiusClicked from '@/../public/svgs/workspace/workspaceHistory/radiusClicked.svg';
+import arrow from '@/../public/svgs/workspace/workspaceHistory/arrow.svg';
+import detailHistoryRadius from '@/../public/svgs/workspace/workspaceHistory/detailHistoryRadius.svg';
+
+import { TDetailHistorys, THistorys } from '@/types/workspaceHistory';
+import { workspaceHistoryDataConst } from '@/constants/queryKey';
+import { historyDetails } from '@/api/workspace';
+
+import IsToggledImage from './IsToggledImage';
+import ApproveStatusMsg from './ApproveStatusMsg';
+
+interface WorkHistoryListProps {
+  index: number;
+  workspaceHistoryData: THistorys;
+  workoutHistoryIds: number[];
+  workspaceId: number;
+  userId: number;
+  workoutHistoriesLength: number;
+  handleWorkoutHistory: (id: number) => void;
+}
+
+export default function WorkHistoryList({
+  index,
+  workoutHistoryIds,
+  workspaceId,
+  workspaceHistoryData,
+  userId,
+  workoutHistoriesLength,
+  handleWorkoutHistory,
+}: WorkHistoryListProps) {
+  const isToggled = workoutHistoryIds.includes(workspaceHistoryData.id);
+
+  const { data: workoutHistorydetails } = useQuery({
+    queryKey: [
+      [
+        workspaceHistoryDataConst.workspaceHistoryDataDetail,
+        workspaceId,
+        userId,
+        workspaceHistoryData.id,
+      ],
+    ],
+    queryFn: () =>
+      historyDetails({
+        workspaceId,
+        userId,
+        workoutHistoryId: workspaceHistoryData.id,
+      }),
+    enabled: isToggled,
+  });
+
+  return (
+    <div className='flex'>
+      <span className='text-[#9C9EA3] text-[10px]'>
+        {workspaceHistoryData.createdAt[index] ===
+        workspaceHistoryData.createdAt ? (
+          <></>
+        ) : (
+          workspaceHistoryData.createdAt.substring(5, 10)
+        )}
+      </span>
+      <div className='flex flex-col items-center px-5'>
+        <Image
+          src={isToggled ? radiusClicked : radius}
+          alt={isToggled ? 'radiusClicked' : 'radius'}
+        />
+        <IsToggledImage
+          index={index}
+          isToggled={isToggled}
+          workoutHistoriesLength={workoutHistoriesLength}
+        />
+      </div>
+      <div>
+        <div
+          onClick={() => {
+            handleWorkoutHistory(workspaceHistoryData.id);
+          }}
+        >
+          <span
+            className={`text-base flex -mt-1 ${
+              isToggled ? 'text-[#4B5563]' : 'text-[#6B7280]'
+            }`}
+          >
+            {workspaceHistoryData.sumOfScore}점 운동 기록
+            {isToggled ? (
+              <></>
+            ) : (
+              <Image src={arrow} alt='arrow' className='w-[4px] ml-2' />
+            )}
+          </span>
+        </div>
+        <ApproveStatusMsg isApproved={workspaceHistoryData.isApproved} />
+        {isToggled && (
+          <div className='w-40 min-h-[85px] bg-[#FDFDFD] drop-shadow-md rounded-lg mt-2 pt-1 pb-2'>
+            <div>
+              {workoutHistorydetails?.data.map(
+                (historyDetail: TDetailHistorys) => (
+                  <div className='h-5 flex items-center' key={historyDetail.id}>
+                    <Image
+                      className='mx-2'
+                      src={detailHistoryRadius}
+                      alt='detailRadius'
+                    />
+                    <div>
+                      <span className='text-[#4B5563] text-xs'>
+                        {historyDetail.mission} {historyDetail.count} 회 -{' '}
+                        {historyDetail.totalScore}p
+                      </span>
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkoutHistoryList.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkoutHistoryList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import speechBubble1 from '@/../public/svgs/workspace/speechBubble/speechBubble1.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
@@ -8,16 +8,21 @@ import WorkspaceTitle from '@/app/(afterLogin)/workspace/[workspaceId]/_componen
 import WorkspaceGimmi from '@/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi';
 
 import type { TQueryTypes } from '@/types/workspaceHistory';
+import { useEffect, useState } from 'react';
+import { cheerUpMessages } from '@/constants/cheerUpMessage';
 
 type TWorkspaceGimmiTitleTypes = {
   queryData: TQueryTypes | null;
-  randomMessage: string;
 };
 
-function WorkspaceGimmiTitle({
-  queryData,
-  randomMessage,
-}: TWorkspaceGimmiTitleTypes) {
+function WorkspaceGimmiTitle({ queryData }: TWorkspaceGimmiTitleTypes) {
+  const [randomMessage, setRandomMessage] = useState(``);
+
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * cheerUpMessages.length);
+    setRandomMessage(cheerUpMessages[randomIndex].message);
+  }, []);
+
   return (
     <div>
       {queryData && (

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceGimmiTitle.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+
+import speechBubble1 from '@/../public/svgs/workspace/speechBubble/speechBubble1.svg';
+import speechBubble2 from '@/../public/svgs/workspace/speechBubble/speechBubble2.svg';
+import speechBubble3 from '@/../public/svgs/workspace/speechBubble/speechBubble3.svg';
+
+import WorkspaceTitle from '@/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle';
+import WorkspaceGimmi from '@/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi';
+
+import type { TQueryTypes } from '@/types/workspaceHistory';
+
+type TWorkspaceGimmiTitleTypes = {
+  queryData: TQueryTypes | null;
+  randomMessage: string;
+};
+
+function WorkspaceGimmiTitle({
+  queryData,
+  randomMessage,
+}: TWorkspaceGimmiTitleTypes) {
+  return (
+    <div>
+      {queryData && (
+        <>
+          <WorkspaceTitle name={queryData.name} workout={queryData.workout} />
+          <div className='flex justify-center items-end gap-x-6 h-48 mb-5'>
+            <WorkspaceGimmi
+              workout={queryData.workout}
+              achievementScore={queryData.achievementScore}
+            />
+            <div className='pb-28 relative'>
+              <span className='text-[#4B5563] text-[10px] absolute top-5 right-5 left-6'>
+                {randomMessage}
+              </span>
+              <Image src={speechBubble3} alt='speechBubble3' />
+              <Image
+                className='ml-3 my-2'
+                src={speechBubble2}
+                alt='speechBubble2'
+              />
+              <Image src={speechBubble1} alt='speechBubble1' />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+export default WorkspaceGimmiTitle;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
@@ -1,0 +1,63 @@
+import Image from 'next/image';
+
+import verticalLine from '@/../public/svgs/workspace/verticalLine.svg';
+import type { TScoreData } from '@/types/workspaceHistory';
+import type { TWorkspaceHistory } from '@/types/\bworkSpace';
+
+interface WorkspaceScoreBoardProps {
+  workspaceHistoryDatas: TWorkspaceHistory;
+}
+
+function WorkspaceScoreBoard({
+  workspaceHistoryDatas,
+}: WorkspaceScoreBoardProps) {
+  const scoreDatas = [
+    {
+      id: 1,
+      label: '일일 최고 운동점수',
+      value: workspaceHistoryDatas?.bestDailyScore,
+    },
+    {
+      id: 2,
+      label: '누적 운동 기록 횟수',
+      value: workspaceHistoryDatas?.totalWorkoutCount,
+    },
+    {
+      id: 3,
+      label: '1등과의 격차',
+      value: workspaceHistoryDatas?.gabScoreFromFirst,
+    },
+  ];
+  return (
+    <div className='h-14 bg-white rounded-lg mb-4'>
+      <div className='w-full' defaultValue='totalScore'>
+        <div className='flex gap-x-4 pl-7 pt-2 justify-items-center'>
+          <div className='flex flex-col items-center'>
+            <span className='text-[#9C9EA3] text-[10px]'>총 점수</span>
+            <span className='text-[#1F2937] text-base'>
+              {workspaceHistoryDatas?.totalContributedScore}점
+            </span>
+          </div>
+          <Image src={verticalLine} alt='verticalLine' />
+          {scoreDatas.map((scoreData: TScoreData) => {
+            return (
+              <div
+                className='flex flex-col items-center justify-center'
+                key={scoreData.id}
+              >
+                <span className='text-[#9C9EA3] text-[10px]'>
+                  {scoreData.label}
+                </span>
+                <span className='text-[#1F2937] text-sm pt-1'>
+                  {scoreData.value}점
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WorkspaceScoreBoard;

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import verticalLine from '@/../public/svgs/workspace/verticalLine.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/_components/WorkspaceScoreBoard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 
 import verticalLine from '@/../public/svgs/workspace/verticalLine.svg';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
@@ -17,7 +17,7 @@ import { workspaceHistoryData } from '@/constants/queryKey';
 import { cheerUpMessages } from '@/constants/cheerUpMessage';
 import { historyDetails, workspaceHistorys } from '@/api/workspace';
 
-import WorkspaceScoreBoard from './_components/workspaceScoreBoard';
+import WorkspaceScoreBoard from './_components/WorkspaceScoreBoard';
 import WorkspaceGimmiTitle from './_components/WorkspaceGimmiTitle';
 
 import type {
@@ -39,7 +39,10 @@ function Page() {
   const [randomMessage, setRandomMessage] = useState(``);
   const [queryData, setQueryData] = useState<TQueryTypes | null>(null);
 
-  const [workoutMissions, setWorkoutMissions] = useState<THistoryDetails[]>([]);
+  const [historyDetailMissions, setHistoryDetailMissions] = useState<
+    THistoryDetails[]
+  >([]);
+
   const [isWorkoutHistoryDetail, setIsWorkoutHistoryDetail] = useState(false);
 
   useEffect(() => {
@@ -51,7 +54,6 @@ function Page() {
       searchParams.get('achievementScore') || '0',
       10
     );
-
     setQueryData({
       userId: userId,
       name: name || '',
@@ -126,24 +128,22 @@ function Page() {
 
   useEffect(() => {
     if (workspaceHistoryDetail) {
-      const isworkDetail = workoutMissions.some(
-        (mission) => mission.id === workoutHistoryId
-      );
+      setHistoryDetailMissions((prev) => {
+        const isworkDetail = prev.some(
+          (mission) => mission.id === workoutHistoryId
+        );
 
-      if (!isworkDetail) {
-        setWorkoutMissions((prev) => [
-          ...prev,
-          { id: workoutHistoryId, details: workspaceHistoryDetail.data },
-        ]);
-      }
+        if (!isworkDetail) {
+          return [
+            ...prev,
+            { id: workoutHistoryId, details: workspaceHistoryDetail.data },
+          ];
+        }
+        return prev;
+      });
     }
-  }, [
-    workspaceHistoryDetail,
-    workoutHistoryIds,
-    workoutMissions,
-    workoutHistoryId,
-  ]);
-
+  }, [workspaceHistoryDetail, workoutHistoryId]);
+  console.log(historyDetailMissions);
   return (
     <div className='h-screen'>
       <WorkspaceGimmiTitle
@@ -245,8 +245,8 @@ function Page() {
                         )}
                         {isToggled && (
                           <div className='w-40 min-h-[85px] bg-[#FDFDFD] drop-shadow-md rounded-lg mt-2 pt-1 pb-2'>
-                            {workoutMissions[index]?.details ? (
-                              workoutMissions[index].details.map(
+                            {historyDetailMissions[index]?.details ? (
+                              historyDetailMissions[index]?.details.map(
                                 (historyDetail: TDetailHistorys) => {
                                   return (
                                     <div

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
@@ -1,61 +1,31 @@
 'use client';
 
-import radius from '@/../public/svgs/workspace/workspaceHistory/radius.svg';
-import radiusClicked from '@/../public/svgs/workspace/workspaceHistory/radiusClicked.svg';
-import detailHistoryRadius from '@/../public/svgs/workspace/workspaceHistory/detailHistoryRadius.svg';
-import arrow from '@/../public/svgs/workspace/workspaceHistory/arrow.svg';
-import verticalLine from '@/../public/svgs/workspace/verticalLine.svg';
-import detailVertical from '@/../public/svgs/workspace/workspaceHistory/detailVertical.svg';
-import detailVerticalIsToggled from '@/../public/svgs/workspace/workspaceHistory/detailVerticalIsToggled.svg';
-import noGroup from '@/../public/svgs/noGroup.svg';
-
-import speechBubble1 from '@/../public/svgs/workspace/speechBubble/speechBubble1.svg';
-import speechBubble2 from '@/../public/svgs/workspace/speechBubble/speechBubble2.svg';
-import speechBubble3 from '@/../public/svgs/workspace/speechBubble/speechBubble3.svg';
-
-import { workspaceHistoryData } from '@/constants/queryKey';
-import { historyDetails, workspaceHistorys } from '@/api/workspace';
-import { cheerUpMessages } from '@/constants/cheerUpMessage';
-
-import WorkspaceTitle from '@/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceTitle';
-import WorkspaceGimmi from '@/app/(afterLogin)/workspace/[workspaceId]/_components/WorkspaceGimmi';
-
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 
-type TScoreData = {
-  id: number;
-  label: string;
-  value: number | string;
-};
+import radius from '@/../public/svgs/workspace/workspaceHistory/radius.svg';
+import radiusClicked from '@/../public/svgs/workspace/workspaceHistory/radiusClicked.svg';
+import detailHistoryRadius from '@/../public/svgs/workspace/workspaceHistory/detailHistoryRadius.svg';
+import arrow from '@/../public/svgs/workspace/workspaceHistory/arrow.svg';
+import detailVertical from '@/../public/svgs/workspace/workspaceHistory/detailVertical.svg';
+import detailVerticalIsToggled from '@/../public/svgs/workspace/workspaceHistory/detailVerticalIsToggled.svg';
+import noGroup from '@/../public/svgs/noGroup.svg';
 
-type THistorys = {
-  id: number;
-  isApproved: string;
-  createdAt: string;
-  sumOfScore: number;
-};
+import { workspaceHistoryData } from '@/constants/queryKey';
+import { cheerUpMessages } from '@/constants/cheerUpMessage';
+import { historyDetails, workspaceHistorys } from '@/api/workspace';
 
-interface IQueryTypes {
-  userId: number;
-  name: string;
-  workout: boolean;
-  achievementScore: number;
-}
+import WorkspaceScoreBoard from './_components/workspaceScoreBoard';
+import WorkspaceGimmiTitle from './_components/WorkspaceGimmiTitle';
 
-type TDetailHistorys = {
-  id: number;
-  count: number;
-  mission: string;
-  totalScore: number;
-};
-
-type THistoryDetails = {
-  id: number;
-  details: TDetailHistorys[];
-};
+import type {
+  THistorys,
+  TQueryTypes,
+  TDetailHistorys,
+  THistoryDetails,
+} from '@/types/workspaceHistory';
 
 const cheerUpMessage = cheerUpMessages;
 
@@ -63,10 +33,11 @@ function Page() {
   const workspaceId = useParams();
   const workspaceIdNumber = Number(workspaceId.workspaceId);
 
-  const [workoutHistoryIds, setWorkoutHistoryIds] = useState<number[]>([]);
   const [workoutHistoryId, setWorkoutHistoryId] = useState<number>(0);
+  const [workoutHistoryIds, setWorkoutHistoryIds] = useState<number[]>([]);
+
   const [randomMessage, setRandomMessage] = useState(``);
-  const [queryData, setQueryData] = useState<IQueryTypes | null>(null);
+  const [queryData, setQueryData] = useState<TQueryTypes | null>(null);
 
   const [workoutMissions, setWorkoutMissions] = useState<THistoryDetails[]>([]);
   const [isWorkoutHistoryDetail, setIsWorkoutHistoryDetail] = useState(false);
@@ -132,24 +103,6 @@ function Page() {
     },
   });
 
-  const scoreDatas = [
-    {
-      id: 1,
-      label: '일일 최고 운동점수',
-      value: `${workspaceHistoryDatas?.data.totalContributedScore}`,
-    },
-    {
-      id: 2,
-      label: '누적 운동 기록 횟수',
-      value: workspaceHistoryDatas?.data.bestDailyScore,
-    },
-    {
-      id: 3,
-      label: '1등과의 격차',
-      value: workspaceHistoryDatas?.data.gabScoreFromFirst,
-    },
-  ];
-
   const { data: workspaceHistoryDetail } = useQuery({
     queryKey: [
       [
@@ -193,57 +146,15 @@ function Page() {
 
   return (
     <div className='h-screen'>
-      {queryData && (
-        <>
-          <WorkspaceTitle name={queryData.name} workout={queryData.workout} />
-          <div className='flex justify-center items-end gap-x-6 h-48 mb-5'>
-            <WorkspaceGimmi
-              workout={queryData.workout}
-              achievementScore={queryData.achievementScore}
-            />
-            <div className='pb-28 relative'>
-              <span className='text-[#4B5563] text-[10px] absolute top-5 right-5 left-6'>
-                {randomMessage}
-              </span>
-              <Image src={speechBubble3} alt='speechBubble3' />
-              <Image
-                className='ml-3 my-2'
-                src={speechBubble2}
-                alt='speechBubble2'
-              />
-              <Image src={speechBubble1} alt='speechBubble1' />
-            </div>
-          </div>
-        </>
-      )}
-      <div className='h-14 bg-white rounded-lg mb-4'>
-        <div className='w-full' defaultValue='totalScore'>
-          <div className='flex gap-x-4 pl-7 pt-2 justify-items-center'>
-            <div className='flex flex-col items-center'>
-              <span className='text-[#9C9EA3] text-[10px]'>총 점수</span>
-              <span className='text-[#1F2937] text-base'>
-                {workspaceHistoryDatas?.data.totalContributedScore}점
-              </span>
-            </div>
-            <Image src={verticalLine} alt='verticalLine' />
-            {scoreDatas.map((scoreData: TScoreData) => {
-              return (
-                <div
-                  className='flex flex-col items-center justify-center'
-                  key={scoreData.id}
-                >
-                  <span className='text-[#9C9EA3] text-[10px]'>
-                    {scoreData.label}
-                  </span>
-                  <span className='text-[#1F2937] text-sm pt-1'>
-                    {scoreData.value}점
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
+      <WorkspaceGimmiTitle
+        queryData={queryData}
+        randomMessage={randomMessage}
+      />
+
+      <WorkspaceScoreBoard
+        workspaceHistoryDatas={workspaceHistoryDatas?.data}
+      />
+
       <div className='bg-white rounded-lg relative min-h-80 max-h-96 overflow-y-auto'>
         <div className='w-full pt-2 pb-5' defaultValue='myHistory'>
           <span className='text-[#9CA3AF] text-xs pl-5'>

--- a/src/app/(afterLogin)/workspace/_components/NavbarItems.tsx
+++ b/src/app/(afterLogin)/workspace/_components/NavbarItems.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 interface NavbarItemsProps {
-  workspaceId: number;
+  workspaceId: string | null;
   currentSegment: string;
 }
 
@@ -14,7 +14,6 @@ function NavbarItems({ workspaceId, currentSegment }: NavbarItemsProps) {
   useEffect(() => {
     setActiveSegment(currentSegment);
   }, [currentSegment]);
-
   const navItems = [
     {
       name: '그룹홈',

--- a/src/app/(afterLogin)/workspace/_components/NavbarItems.tsx
+++ b/src/app/(afterLogin)/workspace/_components/NavbarItems.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface NavbarItemsProps {
+  workspaceId: number;
+  currentSegment: string;
+}
+
+function NavbarItems({ workspaceId, currentSegment }: NavbarItemsProps) {
+  const [activeSegment, setActiveSegment] = useState<string | null>(null);
+
+  useEffect(() => {
+    setActiveSegment(currentSegment);
+  }, [currentSegment]);
+
+  const navItems = [
+    {
+      name: '그룹홈',
+      path: `/workspace/${workspaceId}`,
+      segments: [workspaceId, 'workspaceHistory'],
+    },
+    {
+      name: '운동하기',
+      path: `/workspace/${workspaceId}/workout`,
+      segments: ['workout', 'register'],
+    },
+    {
+      name: '그룹채팅',
+      path: `/workspace/${workspaceId}/chat`,
+      segments: 'chat',
+    },
+    {
+      name: '운동인증',
+      path: `/workspace/${workspaceId}/auth`,
+      segments: 'auth',
+    },
+  ];
+  return (
+    <>
+      {navItems.map((navItem) => (
+        <Link href={navItem.path} key={navItem.name}>
+          <li
+            className={`${
+              navItem.segments &&
+              activeSegment !== null &&
+              navItem.segments.includes(activeSegment)
+                ? 'text-[#4B5563]'
+                : navItem.segments === activeSegment
+                ? 'text-[#4B5563]'
+                : 'text-[#E5E7EB]'
+            }`}
+          >
+            {navItem.name}
+          </li>
+        </Link>
+      ))}
+    </>
+  );
+}
+
+export default NavbarItems;

--- a/src/app/(afterLogin)/workspace/layout.tsx
+++ b/src/app/(afterLogin)/workspace/layout.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useSelectedLayoutSegment } from 'next/navigation';
 
 import settings from '@/../public/svgs/workspace/settings.svg';
 import BackArrow from '../_components/BackArrow';
+import NavbarItems from './_components/NavbarItems';
 
 type Props = {
   children: ReactNode;
@@ -16,37 +17,9 @@ export default function Layout({ children }: Props) {
   const workspaceId = useSelectedLayoutSegment();
   const workspaceIdNumber = Number(workspaceId);
 
-  const [activeSegment, setActiveSegment] = useState<string | null>(null);
   const pathName = usePathname();
   const segments = pathName.split('/');
   const currentSegment = segments[segments.length - 1];
-
-  useEffect(() => {
-    setActiveSegment(currentSegment);
-  }, [currentSegment]);
-
-  const navItems = [
-    {
-      name: '그룹홈',
-      path: `/workspace/${workspaceIdNumber}`,
-      segments: [workspaceId, 'workspaceHistory'],
-    },
-    {
-      name: '운동하기',
-      path: `/workspace/${workspaceIdNumber}/workout`,
-      segments: ['workout', 'register'],
-    },
-    {
-      name: '그룹채팅',
-      path: `/workspace/${workspaceIdNumber}/chat`,
-      segments: 'chat',
-    },
-    {
-      name: '운동인증',
-      path: `/workspace/${workspaceIdNumber}/auth`,
-      segments: 'auth',
-    },
-  ];
 
   return (
     <div className='h-full'>
@@ -62,23 +35,10 @@ export default function Layout({ children }: Props) {
         <nav className='my-3'>
           <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
           <ul className='flex text-sm gap-x-11 sm:gap-x-8 lg:gap-x-12 justify-center my-2.5 text-[#E5E7EB]'>
-            {navItems.map((navItem) => (
-              <Link href={navItem.path} key={navItem.name}>
-                <li
-                  className={`${
-                    navItem.segments &&
-                    activeSegment !== null &&
-                    navItem.segments.includes(activeSegment)
-                      ? 'text-[#4B5563]'
-                      : navItem.segments === activeSegment
-                      ? 'text-[#4B5563]'
-                      : 'text-[#E5E7EB]'
-                  }`}
-                >
-                  {navItem.name}
-                </li>
-              </Link>
-            ))}
+            <NavbarItems
+              workspaceId={workspaceIdNumber}
+              currentSegment={currentSegment}
+            />
           </ul>
           <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
         </nav>

--- a/src/app/(afterLogin)/workspace/layout.tsx
+++ b/src/app/(afterLogin)/workspace/layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children }: Props) {
           <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
           <ul className='flex text-sm gap-x-11 sm:gap-x-8 lg:gap-x-12 justify-center my-2.5 text-[#E5E7EB]'>
             <NavbarItems
-              workspaceId={workspaceIdNumber}
+              workspaceId={workspaceId}
               currentSegment={currentSegment}
             />
           </ul>

--- a/src/app/(afterLogin)/workspace/layout.tsx
+++ b/src/app/(afterLogin)/workspace/layout.tsx
@@ -49,39 +49,41 @@ export default function Layout({ children }: Props) {
   ];
 
   return (
-    <div className='px-4 py-12 bg-custom-gradient2 h-full'>
-      <div className='flex justify-between'>
-        <BackArrow />
-        <Link href={`/workspaceDetail/${workspaceIdNumber}`}>
-          <div>
-            <Image className='w-6 h-6' src={settings} alt='settings' />
-          </div>
-        </Link>
+    <div className='h-full'>
+      <div className='px-4 pt-12'>
+        <div className='flex justify-between'>
+          <BackArrow />
+          <Link href={`/workspaceDetail/${workspaceIdNumber}`}>
+            <div>
+              <Image className='w-6 h-6' src={settings} alt='settings' />
+            </div>
+          </Link>
+        </div>
+        <nav className='my-3'>
+          <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
+          <ul className='flex text-sm gap-x-11 sm:gap-x-8 lg:gap-x-12 justify-center my-2.5 text-[#E5E7EB]'>
+            {navItems.map((navItem) => (
+              <Link href={navItem.path} key={navItem.name}>
+                <li
+                  className={`${
+                    navItem.segments &&
+                    activeSegment !== null &&
+                    navItem.segments.includes(activeSegment)
+                      ? 'text-[#4B5563]'
+                      : navItem.segments === activeSegment
+                      ? 'text-[#4B5563]'
+                      : 'text-[#E5E7EB]'
+                  }`}
+                >
+                  {navItem.name}
+                </li>
+              </Link>
+            ))}
+          </ul>
+          <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
+        </nav>
       </div>
-      <nav className='my-3'>
-        <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
-        <ul className='flex text-sm gap-x-11 sm:gap-x-8 lg:gap-x-12 justify-center my-2.5 text-[#E5E7EB]'>
-          {navItems.map((navItem) => (
-            <Link href={navItem.path} key={navItem.name}>
-              <li
-                className={`${
-                  navItem.segments &&
-                  activeSegment !== null &&
-                  navItem.segments.includes(activeSegment)
-                    ? 'text-[#4B5563]'
-                    : navItem.segments === activeSegment
-                    ? 'text-[#4B5563]'
-                    : 'text-[#E5E7EB]'
-                }`}
-              >
-                {navItem.name}
-              </li>
-            </Link>
-          ))}
-        </ul>
-        <hr className='border-1 border-[#E5E7EB] w-screen -mx-4' />
-      </nav>
-      {children}
+      <div className='px-4 bg-custom-gradient2'>{children}</div>
     </div>
   );
 }

--- a/src/app/(afterLogin)/workspace/layout.tsx
+++ b/src/app/(afterLogin)/workspace/layout.tsx
@@ -7,7 +7,6 @@ import { usePathname, useSelectedLayoutSegment } from 'next/navigation';
 
 import settings from '@/../public/svgs/workspace/settings.svg';
 import BackArrow from '../_components/BackArrow';
-import { workspace } from '@/constants/queryKey';
 
 type Props = {
   children: ReactNode;
@@ -30,22 +29,22 @@ export default function Layout({ children }: Props) {
     {
       name: '그룹홈',
       path: `/workspace/${workspaceIdNumber}`,
-      segment: workspaceIdNumber,
+      segments: [workspaceId, 'workspaceHistory'],
     },
     {
       name: '운동하기',
       path: `/workspace/${workspaceIdNumber}/workout`,
-      segment: 'workout',
+      segments: ['workout', 'register'],
     },
     {
       name: '그룹채팅',
       path: `/workspace/${workspaceIdNumber}/chat`,
-      segment: 'chat',
+      segments: 'chat',
     },
     {
       name: '운동인증',
       path: `/workspace/${workspaceIdNumber}/auth`,
-      segment: 'auth',
+      segments: 'auth',
     },
   ];
 
@@ -66,7 +65,11 @@ export default function Layout({ children }: Props) {
             <Link href={navItem.path} key={navItem.name}>
               <li
                 className={`${
-                  navItem.segment == activeSegment
+                  navItem.segments &&
+                  activeSegment !== null &&
+                  navItem.segments.includes(activeSegment)
+                    ? 'text-[#4B5563]'
+                    : navItem.segments === activeSegment
                     ? 'text-[#4B5563]'
                     : 'text-[#E5E7EB]'
                 }`}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,10 +1,10 @@
 export const workspace = {
-  mylists: "mylists",
-  all_lists: "all-lists",
-  info: "info",
+  mylists: 'mylists',
+  all_lists: 'all-lists',
+  info: 'info',
 };
 
-export const workspaceHistoryData = {
-  workspaceHistoryData: "workspaceHistory",
-  workspaceHistoryDataDetail: "workspaceHistoryDetail",
+export const workspaceHistoryDataConst = {
+  workspaceHistoryData: 'workspaceHistory',
+  workspaceHistoryDataDetail: 'workspaceHistoryDetail',
 };

--- a/src/hooks/workoutHistory/useWorkoutHistoryIds.ts
+++ b/src/hooks/workoutHistory/useWorkoutHistoryIds.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export default function useWorkoutHistoryIds() {
+  const [workoutHistoryIds, setWorkoutHistoryIds] = useState<number[]>([]);
+  const toggleWorkoutHistoryIds = (id: number) => {
+    setWorkoutHistoryIds((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+    );
+  };
+
+  const handleWorkoutHistory = (id: number) => {
+    toggleWorkoutHistoryIds(id);
+  };
+
+  return { workoutHistoryIds, handleWorkoutHistory };
+}

--- a/src/hooks/workoutHistory/useWorkoutIdFromParams.ts
+++ b/src/hooks/workoutHistory/useWorkoutIdFromParams.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'next/navigation';
+
+export default function useWorkoutIdFromParams() {
+  const workspaceId = useParams();
+
+  return Number(workspaceId.workspaceId);
+}

--- a/src/types/workSpace.ts
+++ b/src/types/workSpace.ts
@@ -91,17 +91,17 @@ export interface IInfoWorkData {
   workers: IWorker[];
 }
 
-interface IWorkoutHistory {
+type TWorkoutHistory = {
   id: number;
   isApproved: string;
   createdAt: string;
   sumOfScore: number;
-}
+};
 
-export interface IWorkspaceHistory {
+export type TWorkspaceHistory = {
   totalContributedScore: number;
   bestDailyScore: number;
   totalWorkoutCount: number;
-  scoreGapFromFirst: number;
-  workoutHistories: IWorkoutHistory[];
-}
+  gabScoreFromFirst: number;
+  workoutHistories: TWorkoutHistory[];
+};

--- a/src/types/workspaceHistory.ts
+++ b/src/types/workspaceHistory.ts
@@ -6,7 +6,7 @@ type TScoreData = {
 
 type THistorys = {
   id: number;
-  isApproved: string;
+  isApproved: boolean;
   createdAt: string;
   sumOfScore: number;
 };

--- a/src/types/workspaceHistory.ts
+++ b/src/types/workspaceHistory.ts
@@ -1,0 +1,39 @@
+type TScoreData = {
+  id: number;
+  label: string;
+  value: number | string;
+};
+
+type THistorys = {
+  id: number;
+  isApproved: string;
+  createdAt: string;
+  sumOfScore: number;
+};
+
+type TQueryTypes = {
+  userId: number;
+  name: string;
+  workout: boolean;
+  achievementScore: number;
+};
+
+type TDetailHistorys = {
+  id: number;
+  count: number;
+  mission: string;
+  totalScore: number;
+};
+
+type THistoryDetails = {
+  id: number;
+  details: TDetailHistorys[];
+};
+
+export type {
+  TScoreData,
+  THistorys,
+  TQueryTypes,
+  TDetailHistorys,
+  THistoryDetails,
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #55 

## 📝작업 내용

> 개인별 운동 히스토리 페이지 코드를 리팩토링하였고 개인별 히스토리 상세 목록의 쿼리값 요청이 잘못 되어서 수정했습니다. 

## 💬리뷰 요구사항(선택)

> 개인별 운동 히스토리를 컴포넌트로 변경하였고 상세 목록 데이터를 요청할 때 원래는 전역적으로 workoutHistoryId를 서버 통신 코드에 props로 넘겨주어 기존에 있던 상세 목록들이 최근에 클릭된 상세목록들로 덮여씌여졌지만 지금은 workoutHistoryId: workspaceHistoryData.id로 바꿔주어 클릭한 히스토리에 맞게 id를 넘겨주어 의도한 대로 작동하고 있습니다. 
그리고 고민거리는 코드를 리팩토링 하던 중 어디까지 컴포넌트로 변경하여 관리해야 하는지 갈피가 안 잡혀 혹시 코드 보시고 바꾸거나 수정했으면 하는 부분이 있다면 코멘트 남겨 주세요 :)
