### PR TITLE
2차 QA 수정 사항

### DIFF
--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ConfirmationCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ConfirmationCompo.tsx
@@ -2,6 +2,7 @@ import { IWorkoutConfirmationPageProps } from '@/types/workoutConfirmation';
 import ConfirmationProfile from './ConfirmationProfile';
 import ConfirmationCompoObjection from './ConfirmationCompoObjection';
 import ConfirmationCompoConfirm from './ConfirmationCompoConfirm';
+import ConfirmationCompoTime from './ConfirmationCompoTime';
 
 interface IConfirmationCompoProps {
   workoutConfirmationPage: IWorkoutConfirmationPageProps;
@@ -30,15 +31,9 @@ export default function ConfirmationCompo({
             workspaceId={workspaceId}
           />
         )}
-        <div
-          className={`${
-            workoutConfirmationPage.isMine ? 'mr-2' : 'ml-2'
-          } flex items-end `}
-        >
-          <span className='text-[10px] text-[#9CA3AF]'>
-            {workoutConfirmationPage.createdAt.substring(11, 16)}
-          </span>
-        </div>
+        <ConfirmationCompoTime
+          workoutConfirmationPage={workoutConfirmationPage}
+        />
       </div>
     </div>
   );

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ConfirmationCompoTime.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ConfirmationCompoTime.tsx
@@ -1,0 +1,21 @@
+import { IWorkoutConfirmationPageProps } from '@/types/workoutConfirmation';
+
+interface IConfirmationPageProps {
+  workoutConfirmationPage: IWorkoutConfirmationPageProps;
+}
+
+export default function ConfirmationCompoTime({
+  workoutConfirmationPage,
+}: IConfirmationPageProps) {
+  return (
+    <div
+      className={`${
+        workoutConfirmationPage.isMine ? 'mr-2' : 'ml-2'
+      } flex items-end `}
+    >
+      <span className='text-[10px] text-[#9CA3AF]'>
+        {workoutConfirmationPage.createdAt.substring(11, 16)}
+      </span>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ScrollTop.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/_components/ScrollTop.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ScrollTop() {
+  const pathName = usePathname();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathName]);
+
+  return null;
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/page.tsx
@@ -11,13 +11,14 @@ import IsSameDateAsPrevious from './_components/IsSameDataAsPrevious';
 import ConfirmationCompo from './_components/ConfirmationCompo';
 import useInfiniteQuerys from '@/hooks/workoutConfirmation/ useInfiniteQuerys';
 import { useEffect, useRef } from 'react';
+import NoDataUI from '../../_components/NoDataUI';
 
 export default function Page() {
   const workspaceId = useWorkoutIdFromParams();
   const [ref, inView] = useInView({ threshold: 0, delay: 0 });
 
   const scrollBottomRef = useRef<HTMLDivElement | null>(null);
-  const isInitialRender = useRef(true);
+  const isInitialRender = useRef<boolean>(true);
 
   const workoutConfirmation = useInfiniteQuerys({
     queryKey: ['workoutConfirmations', workspaceId],
@@ -35,39 +36,51 @@ export default function Page() {
     );
 
   useEffect(() => {
-    if (scrollBottomRef.current && isInitialRender) {
+    if (
+      isInitialRender.current &&
+      workoutConfirmationPages &&
+      workoutConfirmationPages.length
+    ) {
       scrollBottomRef.current?.scrollIntoView({ behavior: 'auto' });
       isInitialRender.current = false;
     }
   }, [workoutConfirmationPages]);
 
   return (
-    <div className='h-full'>
+    <div className='h-screen'>
       <div ref={ref} />
       <div className='-mx-4 px-4 bg-[#F1F7FF] -mt-3 pb-3'>
-        {workoutConfirmationPages?.map(
-          (
-            workoutConfirmationPage: IWorkoutConfirmationPageProps,
-            index: number
-          ) => {
-            return (
-              <div
-                key={`${workoutConfirmationPage.workoutConfirmationId}-${
-                  workoutConfirmationPage.objectionId || 'noObjection'
-                }-${workoutConfirmationPage.createdAt}`}
-              >
-                <IsSameDateAsPrevious
-                  workoutConfirmationPages={workoutConfirmationPages}
-                  workoutConfirmationPage={workoutConfirmationPage}
-                  index={index}
-                />
-                <ConfirmationCompo
-                  workoutConfirmationPage={workoutConfirmationPage}
-                  workspaceId={workspaceId}
-                />
-              </div>
-            );
-          }
+        {workoutConfirmationPages?.length === 0 ? (
+          <div>
+            <NoDataUI content='아직 운동 인증이 없어요.' />
+          </div>
+        ) : (
+          <div>
+            {workoutConfirmationPages?.map(
+              (
+                workoutConfirmationPage: IWorkoutConfirmationPageProps,
+                index: number
+              ) => {
+                return (
+                  <div
+                    key={`${workoutConfirmationPage.workoutConfirmationId}-${
+                      workoutConfirmationPage.objectionId || 'noObjection'
+                    }-${workoutConfirmationPage.createdAt}`}
+                  >
+                    <IsSameDateAsPrevious
+                      workoutConfirmationPages={workoutConfirmationPages}
+                      workoutConfirmationPage={workoutConfirmationPage}
+                      index={index}
+                    />
+                    <ConfirmationCompo
+                      workoutConfirmationPage={workoutConfirmationPage}
+                      workspaceId={workspaceId}
+                    />
+                  </div>
+                );
+              }
+            )}
+          </div>
         )}
         <ObjectionBell
           workspaceId={workspaceId}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfimationDetailImage.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfimationDetailImage.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+
+import confirmDetailNoImage from '@/../public/svgs/workspace/workspaceConfirmaion/confirmDetailNoImage.svg';
+import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
+
+interface IConfirmationDetailImage {
+  workspaceConfirmationDetail: IWorkspaceConfirmationDetailProps | undefined;
+}
+
+export default function ConfirmationDetailImage({
+  workspaceConfirmationDetail,
+}: IConfirmationDetailImage) {
+  return (
+    <div className='w-full h-[380px] bg-[#E5E7EB] mt-5 flex justify-center relative'>
+      {workspaceConfirmationDetail?.workoutConfirmationImageUrl === '' ? (
+        <Image src={confirmDetailNoImage} alt='confirmDetailNoImage' />
+      ) : (
+        <Image
+          src={workspaceConfirmationDetail?.workoutConfirmationImageUrl}
+          alt='Image'
+          loader={({ src }) => src}
+          loading='lazy'
+          sizes='360px'
+          fill
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 
 import ConfirmationDetailImage from './ConfimationDetailImage';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import ConfirmationDetailImage from './ConfimationDetailImage';
+import ConfirmationDetailProfile from './ConfirmationDetailProfile';
+import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
+import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
+import { workoutConfirmaionsDetail } from '@/api/workspaceConfirmaion';
+
+interface IConfirmationDetailCompoProps {
+  workoutConfirmationId: number;
+}
+
+export default function ConfirmationDetailCompo({
+  workoutConfirmationId,
+}: IConfirmationDetailCompoProps) {
+  const workspaceId = useWorkoutIdFromParams();
+
+  const { data: workspaceConfirmationDetail } = useQuery<{
+    data: IWorkspaceConfirmationDetailProps;
+  }>({
+    queryKey: [
+      'workspaceConfimationDetail',
+      workspaceId,
+      workoutConfirmationId,
+    ],
+    queryFn: () =>
+      workoutConfirmaionsDetail({
+        workspaceId,
+        workoutConfirmationId,
+      }),
+  });
+  return (
+    <div>
+      <ConfirmationDetailProfile
+        workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
+      />
+      <div className='my-5'>
+        <span className='text-base text-[#1F2937]'>
+          {workspaceConfirmationDetail?.data.comment}
+        </span>
+        <ConfirmationDetailImage
+          workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailCompo.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import ConfirmationDetailImage from './ConfimationDetailImage';
 import ConfirmationDetailProfile from './ConfirmationDetailProfile';
 import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailObjectionInput.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailObjectionInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { workoutObjectionReason } from '@/api/workspaceConfirmaion';
 import {
   DialogClose,
@@ -55,7 +57,7 @@ export default function ConfirmationDetailObjectionInput({
   return (
     <DialogContent
       className={`w-72 ${
-        reasonInput.length <= 9 ? 'h-[190px]' : 'h-[165px]'
+        reasonInput.length <= 10 ? 'h-[190px]' : 'h-[165px]'
       } rounded-lg`}
     >
       <DialogHeader>

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailObjectionInput.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailObjectionInput.tsx
@@ -1,0 +1,100 @@
+import { workoutObjectionReason } from '@/api/workspaceConfirmaion';
+import {
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
+import { DialogDescription } from '@radix-ui/react-dialog';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+interface IConfirmationDetailObjectionInputProps {
+  workoutConfirmationId: number;
+}
+
+export default function ConfirmationDetailObjectionInput({
+  workoutConfirmationId,
+}: IConfirmationDetailObjectionInputProps) {
+  const router = useRouter();
+  const [reasonInput, setReasonInput] = useState('');
+  const workspaceId = useWorkoutIdFromParams();
+
+  const objectionReason = useMutation({
+    mutationFn: workoutObjectionReason,
+    onSuccess: (data) => {
+      console.log('Success:', data);
+      alert('이의 신청이 성공적으로 제출되었습니다.');
+      router.push(`/workspace/${workspaceId}/workspaceConfirmation`);
+    },
+    onError: (error) => {
+      console.error('Error:', error);
+      alert('이의 신청 제출 중 오류가 발생했습니다.');
+    },
+  });
+
+  const handleReasonPost = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    if (reasonInput.length < 10) {
+      alert('10자 이상 작성하셔야 합니다.');
+    }
+
+    if (reasonInput.length >= 10) {
+      objectionReason.mutate({
+        workspaceId,
+        workoutConfirmationId,
+        objectionReason: reasonInput,
+      });
+    }
+  };
+
+  return (
+    <DialogContent
+      className={`w-72 ${
+        reasonInput.length <= 9 ? 'h-[190px]' : 'h-[165px]'
+      } rounded-lg`}
+    >
+      <DialogHeader>
+        <DialogTitle className='-mb-2' />
+        <DialogDescription className='text-base text-[#1F2937]'>
+          이의 신청 이유를 입력해주세요.
+        </DialogDescription>
+      </DialogHeader>
+      <div>
+        <input
+          className='w-60 h-10 rounded-lg bg-[#F9FAFB] text-sm text-[#B7C4D5] pl-3'
+          value={reasonInput}
+          onChange={(e) => setReasonInput(e.target.value)}
+        />
+        {reasonInput.length <= 10 ? (
+          <span className='text-[8px] text-[#F87171] ml-2'>
+            이의 신청 이유는 10자 이상 작성해주세요.
+          </span>
+        ) : (
+          <></>
+        )}
+      </div>
+      <DialogFooter>
+        <div>
+          <hr className='absolute left-1/2 -translate-x-1/2 w-72 border-l border-[#E5E7EB]' />
+          <div className='flex justify-between mx-7 items-center'>
+            <DialogClose asChild>
+              <span className='text-sm text-[#B7C4D5]'>cancel</span>
+            </DialogClose>
+            <hr className='h-[45px] border-l border-[#E5E7EB]' />
+            <button
+              className='text-sm text-[#3B82F6] mr-3'
+              onClick={handleReasonPost}
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailProfile.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationDetailProfile.tsx
@@ -1,0 +1,26 @@
+import ConfirmationProfileImg from '../../_components/ConfirmationProfileImg';
+import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
+
+interface IConfirmationDetailProfileProps {
+  workspaceConfirmationDetail: IWorkspaceConfirmationDetailProps | undefined;
+}
+
+export default function ConfirmationDetailProfile({
+  workspaceConfirmationDetail,
+}: IConfirmationDetailProfileProps) {
+  return (
+    <div className='flex items-center ml-1 mt-1.5'>
+      <ConfirmationProfileImg
+        profileImageUrlParams={workspaceConfirmationDetail?.profileImageUrl}
+      />
+      <div className='flex flex-col ml-3 mt-1'>
+        <span className='text-base text-[#1F2937]'>
+          {workspaceConfirmationDetail?.nickname}
+        </span>
+        <span className='text-[10px] text-[#848D99]'>
+          {workspaceConfirmationDetail?.loginId}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
@@ -12,20 +12,19 @@ import {
   workoutObjections,
   workoutObjectionsVote,
 } from '@/api/workspaceConfirmaion';
+import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
 
 interface IConfirmationObjectionCompo {
   seachParams: ReadonlyURLSearchParams;
-  workspaceId: number;
   objectionId: number;
 }
 
 export default function ConfirmationObjectionCompo({
   seachParams,
-  workspaceId,
   objectionId,
 }: IConfirmationObjectionCompo) {
-  console.log(seachParams);
   const [isObjectionVote, setIsObjection] = useState<boolean | null>(null);
+  const workspaceId = useWorkoutIdFromParams();
 
   const isObjection = seachParams.get('isObjection') === 'false';
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
@@ -1,0 +1,202 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import Image from 'next/image';
+import { ReadonlyURLSearchParams } from 'next/navigation';
+import { DialogTrigger } from '@/components/ui/dialog';
+
+import objectedWorkoutVoteIcon from '@/../public/svgs/workspace/workspaceConfirmaion/objectedWorkoutVoteIcon.svg';
+import ProgressBar from './ProgressBar';
+import RemaineTime from './RemaineTime';
+import {
+  workoutObjections,
+  workoutObjectionsVote,
+} from '@/api/workspaceConfirmaion';
+
+interface IConfirmationObjectionCompo {
+  seachParams: ReadonlyURLSearchParams;
+  workspaceId: number;
+  objectionId: number;
+}
+
+export default function ConfirmationObjectionCompo({
+  seachParams,
+  workspaceId,
+  objectionId,
+}: IConfirmationObjectionCompo) {
+  console.log(seachParams);
+  const [isObjectionVote, setIsObjection] = useState<boolean | null>(null);
+
+  const isObjection = seachParams.get('isObjection') === 'false';
+
+  const { data: workoutObjection } = useQuery({
+    queryKey: ['workoutObjection', workspaceId, objectionId],
+    queryFn: () =>
+      workoutObjections({
+        workspaceId,
+        objectionId,
+      }),
+    enabled: !isObjection,
+  });
+
+  const handleVote = (isObjection: boolean) => {
+    setIsObjection((prev) => (prev === isObjection ? null : isObjection));
+  };
+
+  const queryClient = useQueryClient();
+
+  const OBJECTTIONVOTE_QUERYKEY = {
+    workoutObjection: (workspaceId: number, objectionId: number) => [
+      'workoutObjection',
+      workspaceId,
+      objectionId,
+    ],
+  };
+
+  const objectionVote = useMutation({
+    mutationFn: workoutObjectionsVote,
+    onSuccess: (data) => {
+      console.log('Success:', data);
+      alert('이의 신청 투표가 성공적으로 제출되었습니다.');
+
+      queryClient.invalidateQueries({
+        queryKey: OBJECTTIONVOTE_QUERYKEY.workoutObjection(
+          workspaceId,
+          objectionId
+        ),
+      });
+    },
+
+    onError: (error) => {
+      console.error('Error:', error);
+      alert('이의 신청 투표 중 오류가 발생했습니다.');
+    },
+  });
+
+  const handleVotePost = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    if (isObjectionVote === null) {
+      alert('이의신청 투표를 진행해주세요.');
+    }
+
+    if (isObjectionVote !== null) {
+      objectionVote.mutate({
+        workspaceId,
+        objectionId,
+        objectionVote: isObjectionVote,
+      });
+    }
+  };
+
+  const appovalCount =
+    (workoutObjection?.data.approvalCount / workoutObjection?.data.headCount) *
+    100;
+  const rejectionCount =
+    (workoutObjection?.data.rejectionCount / workoutObjection?.data.headCount) *
+    100;
+  if (appovalCount > 100 || rejectionCount > 100) {
+    appovalCount === 100 || rejectionCount === 100;
+  }
+
+  return (
+    <div>
+      {isObjection ? (
+        <div
+          className={
+            ' w-full h-11 bg-[#EFF6FF] rounded-[35px] flex justify-center'
+          }
+        >
+          <DialogTrigger asChild>
+            <button className='w-full text-base text-[#848D99]'>
+              이의 신청하기
+            </button>
+          </DialogTrigger>
+        </div>
+      ) : (
+        <div
+          className={`w-full ${
+            !workoutObjection?.data.inInProgress ? 'h-44' : 'h-42'
+          } border border-[#E5E7EB] rounded-lg p-3`}
+        >
+          <div className='flex'>
+            <Image
+              src={objectedWorkoutVoteIcon}
+              alt='objectedWorkoutVoteIcon'
+            />
+            <span className='text-base text-[#1F2937] ml-1'>
+              {!workoutObjection?.data.inInProgress
+                ? `투표 결과: ${
+                    workoutObjection?.data.confirmationCompletion
+                      ? '찬성'
+                      : '반대'
+                  }`
+                : '이의 신청 투표'}
+            </span>
+          </div>
+          <p className='text-[10px] text-[#1F2937] my-2'>
+            {workoutObjection?.data.reason}
+          </p>
+          <div className='flex justify-end mb-2'>
+            <span className='text-[10px] text-[#848D99]'>
+              {!workoutObjection?.data.inInProgress ? (
+                '투표 종료'
+              ) : (
+                <>
+                  투표 종료까지{' '}
+                  <RemaineTime deadline={workoutObjection?.data.deadline} />
+                </>
+              )}
+              {' * '}
+              {workoutObjection?.data.voteParticipationCount}명 참여
+            </span>
+          </div>
+          {!workoutObjection?.data.inInProgress ? (
+            <div className='h-11 bg-[#3B82F6] text-[#FFFFFF] rounded-[35px] mt-4 flex justify-center items-center opacity-60'>
+              <span className='text-base'>투표 종료</span>
+            </div>
+          ) : (
+            <div>
+              <ProgressBar
+                comment='찬성하기'
+                progressValue={appovalCount}
+                onClick={() => {
+                  if (!workoutObjection?.data.voteCompletion) handleVote(true);
+                }}
+                isObjectionVote={isObjectionVote === true}
+              />
+              <ProgressBar
+                comment='반대하기'
+                progressValue={rejectionCount}
+                onClick={() => {
+                  if (!workoutObjection?.data.voteCompletion) handleVote(false);
+                }}
+                isObjectionVote={isObjectionVote === false}
+              />
+              <div
+                className={`h-11 ${
+                  isObjectionVote !== null ||
+                  workoutObjection?.data.voteCompletion
+                    ? 'bg-[#3B82F6] text-[#FFFFFF]'
+                    : 'bg-[#EFF6FF] text-[#3B82F6]'
+                } rounded-[35px] flex justify-center`}
+              >
+                {workoutObjection?.data.voteCompletion ? (
+                  <div className='text-base flex items-center'>투표완료</div>
+                ) : (
+                  <button
+                    className='text-base w-full'
+                    onClick={handleVotePost}
+                    disabled={objectionVote.isPending}
+                  >
+                    투표하기
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/ConfirmationObjectionCompo.tsx
@@ -1,5 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import Image from 'next/image';
 import { ReadonlyURLSearchParams } from 'next/navigation';
@@ -16,15 +16,14 @@ import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParam
 
 interface IConfirmationObjectionCompo {
   seachParams: ReadonlyURLSearchParams;
-  objectionId: number;
 }
 
 export default function ConfirmationObjectionCompo({
   seachParams,
-  objectionId,
 }: IConfirmationObjectionCompo) {
   const [isObjectionVote, setIsObjection] = useState<boolean | null>(null);
   const workspaceId = useWorkoutIdFromParams();
+  const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
 
   const isObjection = seachParams.get('isObjection') === 'false';
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/confirmationObjection/ConfirmationObjectionCompo.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/confirmationObjection/ConfirmationObjectionCompo.tsx
@@ -8,13 +8,14 @@ import { ReadonlyURLSearchParams } from 'next/navigation';
 import { DialogTrigger } from '@/components/ui/dialog';
 
 import objectedWorkoutVoteIcon from '@/../public/svgs/workspace/workspaceConfirmaion/objectedWorkoutVoteIcon.svg';
-import ProgressBar from './ProgressBar';
-import RemaineTime from './RemaineTime';
+import RemaineTime from '../RemaineTime';
 import {
   workoutObjections,
   workoutObjectionsVote,
 } from '@/api/workspaceConfirmaion';
 import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
+import ConfirmationObjectionProgressBars from './ConfirmationObjectionProgressBars';
+import { IWorkoutObjectionProps } from '@/types/workoutConfirmation';
 
 interface IConfirmationObjectionCompo {
   seachParams: ReadonlyURLSearchParams;
@@ -23,25 +24,23 @@ interface IConfirmationObjectionCompo {
 export default function ConfirmationObjectionCompo({
   seachParams,
 }: IConfirmationObjectionCompo) {
-  const [isObjectionVote, setIsObjection] = useState<boolean | null>(null);
   const workspaceId = useWorkoutIdFromParams();
+  const [isObjectionVote, setIsObjectionVote] = useState<boolean | null>(null);
   const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
 
   const isObjection = seachParams.get('isObjection') === 'false';
 
-  const { data: workoutObjection } = useQuery({
-    queryKey: ['workoutObjection', workspaceId, objectionId],
-    queryFn: () =>
-      workoutObjections({
-        workspaceId,
-        objectionId,
-      }),
-    enabled: !isObjection,
-  });
-
-  const handleVote = (isObjection: boolean) => {
-    setIsObjection((prev) => (prev === isObjection ? null : isObjection));
-  };
+  const { data: workoutObjection } = useQuery<{ data: IWorkoutObjectionProps }>(
+    {
+      queryKey: ['workoutObjection', workspaceId, objectionId],
+      queryFn: () =>
+        workoutObjections({
+          workspaceId,
+          objectionId,
+        }),
+      enabled: !isObjection,
+    }
+  );
 
   const queryClient = useQueryClient();
 
@@ -88,16 +87,6 @@ export default function ConfirmationObjectionCompo({
       });
     }
   };
-
-  const appovalCount =
-    (workoutObjection?.data.approvalCount / workoutObjection?.data.headCount) *
-    100;
-  const rejectionCount =
-    (workoutObjection?.data.rejectionCount / workoutObjection?.data.headCount) *
-    100;
-  if (appovalCount > 100 || rejectionCount > 100) {
-    appovalCount === 100 || rejectionCount === 100;
-  }
 
   return (
     <div>
@@ -157,21 +146,10 @@ export default function ConfirmationObjectionCompo({
             </div>
           ) : (
             <div>
-              <ProgressBar
-                comment='찬성하기'
-                progressValue={appovalCount}
-                onClick={() => {
-                  if (!workoutObjection?.data.voteCompletion) handleVote(true);
-                }}
-                isObjectionVote={isObjectionVote === true}
-              />
-              <ProgressBar
-                comment='반대하기'
-                progressValue={rejectionCount}
-                onClick={() => {
-                  if (!workoutObjection?.data.voteCompletion) handleVote(false);
-                }}
-                isObjectionVote={isObjectionVote === false}
+              <ConfirmationObjectionProgressBars
+                isObjectionVote={isObjectionVote}
+                setIsObjectionVote={setIsObjectionVote}
+                workoutObjection={workoutObjection?.data}
               />
               <div
                 className={`h-11 ${

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/confirmationObjection/ConfirmationObjectionProgressBars.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/_components/confirmationObjection/ConfirmationObjectionProgressBars.tsx
@@ -1,0 +1,48 @@
+import { IWorkoutObjectionProps } from '@/types/workoutConfirmation';
+import ProgressBar from '../ProgressBar';
+import { Dispatch, SetStateAction } from 'react';
+
+interface IConfirmationObjectionProgressBarsProps {
+  isObjectionVote: boolean | null;
+  setIsObjectionVote: Dispatch<SetStateAction<boolean | null>>;
+  workoutObjection: IWorkoutObjectionProps;
+}
+
+export default function ConfirmationObjectionProgressBars({
+  isObjectionVote,
+  setIsObjectionVote,
+  workoutObjection,
+}: IConfirmationObjectionProgressBarsProps) {
+  const handleVote = (isObjection: boolean) => {
+    setIsObjectionVote((prev) => (prev === isObjection ? null : isObjection));
+  };
+
+  const appovalCount =
+    (workoutObjection?.approvalCount / workoutObjection?.headCount) * 100;
+  const rejectionCount =
+    (workoutObjection?.rejectionCount / workoutObjection?.headCount) * 100;
+
+  if (appovalCount > 100 || rejectionCount > 100) {
+    appovalCount === 100 || rejectionCount === 100;
+  }
+  return (
+    <div>
+      <ProgressBar
+        comment='찬성하기'
+        progressValue={appovalCount}
+        onClick={() => {
+          if (!workoutObjection?.voteCompletion) handleVote(true);
+        }}
+        isObjectionVote={isObjectionVote === true}
+      />
+      <ProgressBar
+        comment='반대하기'
+        progressValue={rejectionCount}
+        onClick={() => {
+          if (!workoutObjection?.voteCompletion) handleVote(false);
+        }}
+        isObjectionVote={isObjectionVote === false}
+      />
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -12,19 +12,14 @@ import {
 } from '@/components/ui/dialog';
 
 import { DialogDescription } from '@radix-ui/react-dialog';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
-import {
-  workoutConfirmaionsDetail,
-  workoutObjectionReason,
-} from '@/api/workspaceConfirmaion';
+import { workoutObjectionReason } from '@/api/workspaceConfirmaion';
 
 import ScrollTop from '../_components/ScrollTop';
-import ConfirmationDetailProfile from './_components/ConfirmationDetailProfile';
-import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
-import ConfirmationDetailImage from './_components/ConfimationDetailImage';
 import ConfirmationobjectionCompo from './_components/ConfirmationObjectionCompo';
+import ConfirmationDetailCompo from './_components/ConfirmationDetailCompo';
 
 export default function Page() {
   const [reasonInput, setReasonInput] = useState('');
@@ -35,23 +30,7 @@ export default function Page() {
     seachParams.get('workoutConfirmationId') || '0',
     10
   );
-
   const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
-
-  const { data: workspaceConfirmationDetail } = useQuery<{
-    data: IWorkspaceConfirmationDetailProps;
-  }>({
-    queryKey: [
-      'workspaceConfimationDetail',
-      workspaceId,
-      workoutConfirmationId,
-    ],
-    queryFn: () =>
-      workoutConfirmaionsDetail({
-        workspaceId,
-        workoutConfirmationId,
-      }),
-  });
 
   const objectionReason = useMutation({
     mutationFn: workoutObjectionReason,
@@ -85,23 +64,12 @@ export default function Page() {
   return (
     <div className='h-screen'>
       <ScrollTop />
-      <ConfirmationDetailProfile
-        workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
-      />
-      <div className='my-5'>
-        <span className='text-base text-[#1F2937]'>
-          {workspaceConfirmationDetail?.data.comment}
-        </span>
-        <ConfirmationDetailImage
-          workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
-        />
-      </div>
+      <ConfirmationDetailCompo workoutConfirmationId={workoutConfirmationId} />
 
       {/* 이의 신청 팝업창 */}
       <Dialog>
         <ConfirmationobjectionCompo
           seachParams={seachParams}
-          workspaceId={workspaceId}
           objectionId={objectionId}
         />
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/dialog';
 
 import objectedWorkoutVoteIcon from '@/../public/svgs/workspace/workspaceConfirmaion/objectedWorkoutVoteIcon.svg';
-import confirmDetailNoImage from '@/../public/svgs/workspace/workspaceConfirmaion/confirmDetailNoImage.svg';
 
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -31,6 +30,7 @@ import RemaineTime from './_components/RemaineTime';
 import ScrollTop from '../_components/ScrollTop';
 import ConfirmationDetailProfile from './_components/ConfirmationDetailProfile';
 import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
+import ConfirmationDetailImage from './_components/ConfimationDetailImage';
 
 export default function Page() {
   const [reasonInput, setReasonInput] = useState('');
@@ -170,23 +170,9 @@ export default function Page() {
         <span className='text-base text-[#1F2937]'>
           {workspaceConfirmationDetail?.data.comment}
         </span>
-        <div className='w-full h-[380px] bg-[#E5E7EB] mt-5 flex justify-center relative'>
-          {workspaceConfirmationDetail?.data.workoutConfirmationImageUrl ===
-          '' ? (
-            <Image src={confirmDetailNoImage} alt='confirmDetailNoImage' />
-          ) : (
-            <Image
-              src={
-                workspaceConfirmationDetail?.data.workoutConfirmationImageUrl
-              }
-              alt='Image'
-              loader={({ src }) => src}
-              loading='lazy'
-              sizes='360px'
-              fill
-            />
-          )}
-        </div>
+        <ConfirmationDetailImage
+          workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
+        />
       </div>
 
       {/* 이의 신청 팝업창 */}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -5,7 +5,7 @@ import { Dialog } from '@/components/ui/dialog';
 import { useSearchParams } from 'next/navigation';
 
 import ScrollTop from '../_components/ScrollTop';
-import ConfirmationObjectionCompo from './_components/ConfirmationObjectionCompo';
+import ConfirmationObjectionCompo from './_components/confirmationObjection/ConfirmationObjectionCompo';
 import ConfirmationDetailCompo from './_components/ConfirmationDetailCompo';
 import ConfirmationDetailObjectionInput from './_components/ConfirmationDetailObjectionInput';
 

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import { useState } from 'react';
 
 import {
@@ -10,31 +9,25 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 
-import objectedWorkoutVoteIcon from '@/../public/svgs/workspace/workspaceConfirmaion/objectedWorkoutVoteIcon.svg';
-
 import { DialogDescription } from '@radix-ui/react-dialog';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
 import {
   workoutConfirmaionsDetail,
   workoutObjectionReason,
-  workoutObjections,
-  workoutObjectionsVote,
 } from '@/api/workspaceConfirmaion';
-import ProgressBar from './_components/ProgressBar';
-import RemaineTime from './_components/RemaineTime';
+
 import ScrollTop from '../_components/ScrollTop';
 import ConfirmationDetailProfile from './_components/ConfirmationDetailProfile';
 import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
 import ConfirmationDetailImage from './_components/ConfimationDetailImage';
+import ConfirmationobjectionCompo from './_components/ConfirmationObjectionCompo';
 
 export default function Page() {
   const [reasonInput, setReasonInput] = useState('');
-  const [isObjectionVote, setIsObjection] = useState<boolean | null>(null);
   const router = useRouter();
   const workspaceId = useWorkoutIdFromParams();
   const seachParams = useSearchParams();
@@ -42,7 +35,6 @@ export default function Page() {
     seachParams.get('workoutConfirmationId') || '0',
     10
   );
-  const isObjection = seachParams.get('isObjection') === 'false';
 
   const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
 
@@ -60,18 +52,6 @@ export default function Page() {
         workoutConfirmationId,
       }),
   });
-
-  const { data: workoutObjection } = useQuery({
-    queryKey: ['workoutObjection', workspaceId, objectionId],
-    queryFn: () =>
-      workoutObjections({
-        workspaceId,
-        objectionId,
-      }),
-    enabled: !isObjection,
-  });
-
-  const queryClient = useQueryClient();
 
   const objectionReason = useMutation({
     mutationFn: workoutObjectionReason,
@@ -102,64 +82,6 @@ export default function Page() {
     }
   };
 
-  const handleVote = (isObjection: boolean) => {
-    setIsObjection((prev) => (prev === isObjection ? null : isObjection));
-  };
-
-  const OBJECTTIONVOTE_QUERYKEY = {
-    workoutObjection: (workspaceId: number, objectionId: number) => [
-      'workoutObjection',
-      workspaceId,
-      objectionId,
-    ],
-  };
-
-  const objectionVote = useMutation({
-    mutationFn: workoutObjectionsVote,
-    onSuccess: (data) => {
-      console.log('Success:', data);
-      alert('이의 신청 투표가 성공적으로 제출되었습니다.');
-
-      queryClient.invalidateQueries({
-        queryKey: OBJECTTIONVOTE_QUERYKEY.workoutObjection(
-          workspaceId,
-          objectionId
-        ),
-      });
-    },
-
-    onError: (error) => {
-      console.error('Error:', error);
-      alert('이의 신청 투표 중 오류가 발생했습니다.');
-    },
-  });
-
-  const handleVotePost = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-
-    if (isObjectionVote === null) {
-      alert('이의신청 투표를 진행해주세요.');
-    }
-
-    if (isObjectionVote !== null) {
-      objectionVote.mutate({
-        workspaceId,
-        objectionId,
-        objectionVote: isObjectionVote,
-      });
-    }
-  };
-
-  const appovalCount =
-    (workoutObjection?.data.approvalCount / workoutObjection?.data.headCount) *
-    100;
-  const rejectionCount =
-    (workoutObjection?.data.rejectionCount / workoutObjection?.data.headCount) *
-    100;
-  if (appovalCount > 100 || rejectionCount > 100) {
-    appovalCount === 100 || rejectionCount === 100;
-  }
-
   return (
     <div className='h-screen'>
       <ScrollTop />
@@ -177,104 +99,11 @@ export default function Page() {
 
       {/* 이의 신청 팝업창 */}
       <Dialog>
-        {isObjection ? (
-          <div
-            className={
-              ' w-full h-11 bg-[#EFF6FF] rounded-[35px] flex justify-center'
-            }
-          >
-            <DialogTrigger asChild>
-              <button className='w-full text-base text-[#848D99]'>
-                이의 신청하기
-              </button>
-            </DialogTrigger>
-          </div>
-        ) : (
-          <div
-            className={`w-full ${
-              !workoutObjection?.data.inInProgress ? 'h-44' : 'h-42'
-            } border border-[#E5E7EB] rounded-lg p-3`}
-          >
-            <div className='flex'>
-              <Image
-                src={objectedWorkoutVoteIcon}
-                alt='objectedWorkoutVoteIcon'
-              />
-              <span className='text-base text-[#1F2937] ml-1'>
-                {!workoutObjection?.data.inInProgress
-                  ? `투표 결과: ${
-                      workoutObjection?.data.confirmationCompletion
-                        ? '찬성'
-                        : '반대'
-                    }`
-                  : '이의 신청 투표'}
-              </span>
-            </div>
-            <p className='text-[10px] text-[#1F2937] my-2'>
-              {workoutObjection?.data.reason}
-            </p>
-            <div className='flex justify-end mb-2'>
-              <span className='text-[10px] text-[#848D99]'>
-                {!workoutObjection?.data.inInProgress ? (
-                  '투표 종료'
-                ) : (
-                  <>
-                    투표 종료까지{' '}
-                    <RemaineTime deadline={workoutObjection?.data.deadline} />
-                  </>
-                )}
-                {' * '}
-                {workoutObjection?.data.voteParticipationCount}명 참여
-              </span>
-            </div>
-            {!workoutObjection?.data.inInProgress ? (
-              <div className='h-11 bg-[#3B82F6] text-[#FFFFFF] rounded-[35px] mt-4 flex justify-center items-center opacity-60'>
-                <span className='text-base'>투표 종료</span>
-              </div>
-            ) : (
-              <>
-                <ProgressBar
-                  comment='찬성하기'
-                  progressValue={appovalCount}
-                  onClick={() => {
-                    if (!workoutObjection?.data.voteCompletion)
-                      handleVote(true);
-                  }}
-                  isObjectionVote={isObjectionVote === true}
-                />
-                <ProgressBar
-                  comment='반대하기'
-                  progressValue={rejectionCount}
-                  onClick={() => {
-                    if (!workoutObjection?.data.voteCompletion)
-                      handleVote(false);
-                  }}
-                  isObjectionVote={isObjectionVote === false}
-                />
-                <div
-                  className={`h-11 ${
-                    isObjectionVote !== null ||
-                    workoutObjection?.data.voteCompletion
-                      ? 'bg-[#3B82F6] text-[#FFFFFF]'
-                      : 'bg-[#EFF6FF] text-[#3B82F6]'
-                  } rounded-[35px] flex justify-center`}
-                >
-                  {workoutObjection?.data.voteCompletion ? (
-                    <div className='text-base flex items-center'>투표완료</div>
-                  ) : (
-                    <button
-                      className='text-base w-full'
-                      onClick={handleVotePost}
-                      disabled={objectionVote.isPending}
-                    >
-                      투표하기
-                    </button>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        )}
+        <ConfirmationobjectionCompo
+          seachParams={seachParams}
+          workspaceId={workspaceId}
+          objectionId={objectionId}
+        />
 
         <DialogContent
           className={`w-72 ${

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -29,6 +29,7 @@ import {
 import ProgressBar from './_components/ProgressBar';
 import RemaineTime from './_components/RemaineTime';
 import ConfirmationProfileImg from '../_components/ConfirmationProfileImg';
+import ScrollTop from '../_components/ScrollTop';
 
 export default function Page() {
   const [reasonInput, setReasonInput] = useState('');
@@ -158,6 +159,7 @@ export default function Page() {
 
   return (
     <div className='h-screen'>
+      <ScrollTop />
       <div className='flex items-center ml-1 mt-1.5'>
         <ConfirmationProfileImg
           profileImageUrlParams={

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -1,65 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { Dialog } from '@/components/ui/dialog';
 
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-
-import { DialogDescription } from '@radix-ui/react-dialog';
-import { useMutation } from '@tanstack/react-query';
-import { useRouter, useSearchParams } from 'next/navigation';
-import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
-import { workoutObjectionReason } from '@/api/workspaceConfirmaion';
+import { useSearchParams } from 'next/navigation';
 
 import ScrollTop from '../_components/ScrollTop';
-import ConfirmationobjectionCompo from './_components/ConfirmationObjectionCompo';
+import ConfirmationObjectionCompo from './_components/ConfirmationObjectionCompo';
 import ConfirmationDetailCompo from './_components/ConfirmationDetailCompo';
+import ConfirmationDetailObjectionInput from './_components/ConfirmationDetailObjectionInput';
 
 export default function Page() {
-  const [reasonInput, setReasonInput] = useState('');
-  const router = useRouter();
-  const workspaceId = useWorkoutIdFromParams();
   const seachParams = useSearchParams();
   const workoutConfirmationId = parseInt(
     seachParams.get('workoutConfirmationId') || '0',
     10
   );
-  const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
-
-  const objectionReason = useMutation({
-    mutationFn: workoutObjectionReason,
-    onSuccess: (data) => {
-      console.log('Success:', data);
-      alert('이의 신청이 성공적으로 제출되었습니다.');
-      router.push(`/workspace/${workspaceId}/workspaceConfirmation`);
-    },
-    onError: (error) => {
-      console.error('Error:', error);
-      alert('이의 신청 제출 중 오류가 발생했습니다.');
-    },
-  });
-
-  const handleReasonPost = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-
-    if (reasonInput.length < 10) {
-      alert('10자 이상 작성하셔야 합니다.');
-    }
-
-    if (reasonInput.length >= 10) {
-      objectionReason.mutate({
-        workspaceId,
-        workoutConfirmationId,
-        objectionReason: reasonInput,
-      });
-    }
-  };
 
   return (
     <div className='h-screen'>
@@ -68,54 +23,11 @@ export default function Page() {
 
       {/* 이의 신청 팝업창 */}
       <Dialog>
-        <ConfirmationobjectionCompo
-          seachParams={seachParams}
-          objectionId={objectionId}
-        />
+        <ConfirmationObjectionCompo seachParams={seachParams} />
 
-        <DialogContent
-          className={`w-72 ${
-            reasonInput.length <= 10 ? 'h-[190px]' : 'h-[165px]'
-          } rounded-lg`}
-        >
-          <DialogHeader>
-            <DialogTitle className='-mb-2' />
-            <DialogDescription className='text-base text-[#1F2937]'>
-              이의 신청 이유를 입력해주세요.
-            </DialogDescription>
-          </DialogHeader>
-          <div>
-            <input
-              className='w-60 h-10 rounded-lg bg-[#F9FAFB] text-sm text-[#B7C4D5] pl-3'
-              value={reasonInput}
-              onChange={(e) => setReasonInput(e.target.value)}
-            />
-            {reasonInput.length <= 10 ? (
-              <span className='text-[8px] text-[#F87171] ml-2'>
-                이의 신청 이유는 10자 이상 작성해주세요.
-              </span>
-            ) : (
-              <></>
-            )}
-          </div>
-          <DialogFooter>
-            <div>
-              <hr className='absolute left-1/2 -translate-x-1/2 w-72 border-l border-[#E5E7EB]' />
-              <div className='flex justify-between mx-7 items-center'>
-                <DialogClose asChild>
-                  <span className='text-sm text-[#B7C4D5]'>cancel</span>
-                </DialogClose>
-                <hr className='h-[45px] border-l border-[#E5E7EB]' />
-                <button
-                  className='text-sm text-[#3B82F6] mr-3'
-                  onClick={handleReasonPost}
-                >
-                  OK
-                </button>
-              </div>
-            </div>
-          </DialogFooter>
-        </DialogContent>
+        <ConfirmationDetailObjectionInput
+          workoutConfirmationId={workoutConfirmationId}
+        />
       </Dialog>
     </div>
   );

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceConfirmation/workspaceConfirmaionDetail/page.tsx
@@ -28,8 +28,9 @@ import {
 } from '@/api/workspaceConfirmaion';
 import ProgressBar from './_components/ProgressBar';
 import RemaineTime from './_components/RemaineTime';
-import ConfirmationProfileImg from '../_components/ConfirmationProfileImg';
 import ScrollTop from '../_components/ScrollTop';
+import ConfirmationDetailProfile from './_components/ConfirmationDetailProfile';
+import { IWorkspaceConfirmationDetailProps } from '@/types/workoutConfirmation';
 
 export default function Page() {
   const [reasonInput, setReasonInput] = useState('');
@@ -45,7 +46,9 @@ export default function Page() {
 
   const objectionId = parseInt(seachParams.get('objectionId') || '0', 10);
 
-  const { data: workspaceConfirmationDetail } = useQuery({
+  const { data: workspaceConfirmationDetail } = useQuery<{
+    data: IWorkspaceConfirmationDetailProps;
+  }>({
     queryKey: [
       'workspaceConfimationDetail',
       workspaceId,
@@ -160,21 +163,9 @@ export default function Page() {
   return (
     <div className='h-screen'>
       <ScrollTop />
-      <div className='flex items-center ml-1 mt-1.5'>
-        <ConfirmationProfileImg
-          profileImageUrlParams={
-            workspaceConfirmationDetail?.data.profileImageUrl
-          }
-        />
-        <div className='flex flex-col ml-3 mt-1'>
-          <span className='text-base text-[#1F2937]'>
-            {workspaceConfirmationDetail?.data.nickname}
-          </span>
-          <span className='text-[10px] text-[#848D99]'>
-            {workspaceConfirmationDetail?.data.loginId}
-          </span>
-        </div>
-      </div>
+      <ConfirmationDetailProfile
+        workspaceConfirmationDetail={workspaceConfirmationDetail?.data}
+      />
       <div className='my-5'>
         <span className='text-base text-[#1F2937]'>
           {workspaceConfirmationDetail?.data.comment}

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
@@ -16,6 +16,7 @@ import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParam
 
 import type { THistorys, TQueryTypes } from '@/types/workspaceHistory';
 import NoDataUI from '../../_components/NoDataUI';
+import ScrollTop from '../workspaceConfirmation/_components/ScrollTop';
 
 function useUserInfo(): TQueryTypes {
   const searchParams = useSearchParams();
@@ -57,6 +58,7 @@ function Page() {
 
   return (
     <div className='h-screen'>
+      <ScrollTop />
       <WorkspaceGimmiTitle queryData={queryData} />
 
       <WorkspaceScoreBoard

--- a/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
+++ b/src/app/(afterLogin)/workspace/[workspaceId]/workspaceHistory/page.tsx
@@ -4,8 +4,6 @@ import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
-import noGroup from '@/../public/svgs/noGroup.svg';
-
 import { workspaceHistoryDataConst } from '@/constants/queryKey';
 import { workspaceHistorys } from '@/api/workspace';
 
@@ -17,6 +15,7 @@ import useWorkoutHistoryIds from '@/hooks/workoutHistory/useWorkoutHistoryIds';
 import useWorkoutIdFromParams from '@/hooks/workoutHistory/useWorkoutIdFromParams';
 
 import type { THistorys, TQueryTypes } from '@/types/workspaceHistory';
+import NoDataUI from '../../_components/NoDataUI';
 
 function useUserInfo(): TQueryTypes {
   const searchParams = useSearchParams();
@@ -70,12 +69,7 @@ function Page() {
             {'<개인별 운동 히스토리 목록>'}
           </span>
           {workspaceHistoryDatas?.data.workoutHistories.length === 0 ? (
-            <div className='h-[230px] flex items-center justify-center flex-col'>
-              <Image src={noGroup} alt='noGroup' className='h-[73px]' />
-              <span className='text-[#4B5563] text-sm mt-5'>
-                아직 운동 히스토리가 없습니다.
-              </span>
-            </div>
+            <NoDataUI content={'아직 운동 히스토리가 없어요.'} />
           ) : (
             <div className='pt-4 pl-6'>
               {workspaceHistoryDatas?.data.workoutHistories.map(

--- a/src/app/(afterLogin)/workspace/_components/NoDataUI.tsx
+++ b/src/app/(afterLogin)/workspace/_components/NoDataUI.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image';
+
+import noGroup from '@/../public/svgs/noGroup.svg';
+
+interface INoDataUI {
+  content: string;
+}
+
+export default function NoDataUI({ content }: INoDataUI) {
+  return (
+    <div className='h-[230px] flex items-center justify-center flex-col'>
+      <Image src={noGroup} alt='noGroup' className='h-[73px]' />
+      <span className='text-[#4B5563] text-sm mt-5'>{content}</span>
+    </div>
+  );
+}

--- a/src/types/workoutConfirmation.ts
+++ b/src/types/workoutConfirmation.ts
@@ -26,3 +26,15 @@ export interface IWorkspaceConfirmationDetailProps {
   profileImageUrl: any;
   workoutConfirmationImageUrl: any;
 }
+
+export interface IWorkoutObjectionProps {
+  approvalCount: number;
+  confirmationCompletion: boolean | null;
+  deadline: string;
+  headCount: number;
+  inInProgress: boolean;
+  reason: string;
+  rejectionCount: number;
+  voteCompletion: boolean | null;
+  voteParticipationCount: number;
+}

--- a/src/types/workoutConfirmation.ts
+++ b/src/types/workoutConfirmation.ts
@@ -17,3 +17,12 @@ export interface IWorkoutConfirmationObjectionListPageProps {
   voteCompletion: boolean;
   workoutConfirmationId: number;
 }
+
+export interface IWorkspaceConfirmationDetailProps {
+  comment: string;
+  loginId: string;
+  nickname: string;
+  objectionId: number | null;
+  profileImageUrl: any;
+  workoutConfirmationImageUrl: any;
+}


### PR DESCRIPTION
## 📝작업 내용

> 인증 페이지 코드 리팩토링
> 페이지 이동 시 스크롤 상단 고정
> 인증 페이지 스크롤 하단 고정 + 처음 렌더링 시 데이터 10개만 요청하도록 수정 + 데이터 매핑이 위로 쌓이도록 수정

## 💬리뷰 요구사항(선택)

> 지금 인증 페이지에서 상태를 추가해서 처음 해당 페이지로 이동하면 그 상태가 true로 변하면서 데이터를 10개만 요청하도록 했습니다. 하지만 스크롤을 올리고 <div ref={ref} />에 도달하여 데이터를 요청하면, 10개보다 더 많이 데이터를 요청하여 불필요한 요청을 하고 있습니다. 이 부분을 어떻게 수정하면 좋을까요..
